### PR TITLE
Add support for XML signing with SHA-256

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ keystore.*
 .idea
 *.iml
 **/.DS_Store
+*.pem
+*.crs
+*.jks

--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ Import the IDP certificate into the new keystore:
         -file ./node_modules/saml-idp/idp-public-cert.pem \
         -alias mylocalidp
 
+Export the keystore password to an environment variable:
+
+    export KEYSTORE_PASS="changeit"
+
 Check to see that both certificates are in fact in the keystore:
 
     keytool -list -keystore keystore.jks
@@ -169,7 +173,7 @@ Wikipedia article on SAML
 [https://en.wikipedia.org/wiki/Security_Assertion_Markup_Language](https://en.wikipedia.org/wiki/Security_Assertion_Markup_Language)
 
 `saml20-clj`  
-[https://github.com/vlacs/saml20-clj](https://github.com/vlacs/saml20-clj)
+[https://github.com/kirasystems/saml20-clj](https://github.com/kirasystems/saml20-clj)
 
 `lein-npm`  
 [https://github.com/RyanMcG/lein-npm](https://github.com/RyanMcG/lein-npm)

--- a/project.clj
+++ b/project.clj
@@ -3,15 +3,15 @@
   :url "http://github.com/quephird/saml-test"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.8.0"]
-                 [compojure "1.5.2"]
+  :dependencies [[org.clojure/clojure "1.9.0"]
+                 [compojure "1.6.1"]
                  [hiccup "1.0.5"]
-                 [org.slf4j/slf4j-api "1.7.22"]
-                 [org.slf4j/slf4j-log4j12 "1.7.22"]
-                 [ring "1.5.1"]
-                 [saml20-clj "0.1.6"]]
+                 [org.slf4j/slf4j-api "1.7.25"]
+                 [org.slf4j/slf4j-log4j12 "1.7.25"]
+                 [ring "1.6.3"]
+                 [kirasystems/saml20-clj "0.1.12"]]
   :plugins [[big-solutions/lein-mvn "0.1.0"]
             [lein-bower "0.5.2"]
             [lein-npm "0.6.2"]]
-  :npm {:dependencies [[saml-idp "0.2.2"]]}
+  :npm {:dependencies [[saml-idp "1.1.0"]]}
   :main saml-test.core)

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
                  [org.slf4j/slf4j-api "1.7.25"]
                  [org.slf4j/slf4j-log4j12 "1.7.25"]
                  [ring "1.6.3"]
-                 [kirasystems/saml20-clj "0.1.12"]]
+                 [kirasystems/saml20-clj "0.1.12"]] ;; As of now this fork supports SHA-256 encryption while the main branch doesn't.
   :plugins [[big-solutions/lein-mvn "0.1.0"]
             [lein-bower "0.5.2"]
             [lein-npm "0.6.2"]]

--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,7 @@
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [compojure "1.6.1"]
                  [hiccup "1.0.5"]
+                 [com.taoensso/timbre "4.10.0"]
                  [org.slf4j/slf4j-api "1.7.25"]
                  [org.slf4j/slf4j-log4j12 "1.7.25"]
                  [ring "1.6.3"]

--- a/src/saml_test/core.clj
+++ b/src/saml_test/core.clj
@@ -4,11 +4,13 @@
             [ring.adapter.jetty :as jetty]
             [saml-test.routes :as routes]))
 
+(def certti (slurp "./node_modules/saml-idp/idp-public-cert.pem"))
+
 (def config
   {:app-name "Test SAML app"
    :base-uri "http://localhost:8081"
    :idp-uri "http://localhost:7000"
-   :idp-cert "MIIEMDCCAxigAwIBAgIJAPZcPVjOJlnMMA0GCSqGSIb3DQEBBQUAMG0xCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1TYW4gRnJhbmNpc2NvMRAwDgYDVQQKEwdKYW5reUNvMR8wHQYDVQQDExZUZXN0IElkZW50aXR5IFByb3ZpZGVyMB4XDTE3MDMxMjE5MjkzNFoXDTM3MDMwNzE5MjkzNFowbTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCkNhbGlmb3JuaWExFjAUBgNVBAcTDVNhbiBGcmFuY2lzY28xEDAOBgNVBAoTB0phbmt5Q28xHzAdBgNVBAMTFlRlc3QgSWRlbnRpdHkgUHJvdmlkZXIwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC02ay1lhBNntX3p+8Wlsq0wlq31rJkBkmlz/CAJz1kQmhwBxpc0icLHdcWwF4BJ3zcV/CtpNpWv8uD+7EPVJKpavbdi318Ug2K2vqZI7Dyvqi3X50+s3uyAG/gIy63h1qwfFOdIVj7YbJiKvUF4/6w4BWbnNgQL3dBNOPEGdzNgzRlffIbRJwDaIpgiY8nE8sAkTmPzaAuKAGc5eedYDZW+xkDHHHFHtpCxnAaDVfwCPxv+uGRP7emSp7TvFHFKmKQUTZh+FYyJfk8yUs6AJTaJOR2mRFrFxht7pRlavWeAbRDaa4wUUgwHNqvjBI47RZnOeplljN4TyLOL9J9tvXJAgMBAAGjgdIwgc8wHQYDVR0OBBYEFD9Q9rcVIp+s4unYzstD/T5hZjNHMIGfBgNVHSMEgZcwgZSAFD9Q9rcVIp+s4unYzstD/T5hZjNHoXGkbzBtMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNU2FuIEZyYW5jaXNjbzEQMA4GA1UEChMHSmFua3lDbzEfMB0GA1UEAxMWVGVzdCBJZGVudGl0eSBQcm92aWRlcoIJAPZcPVjOJlnMMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAJDIaTj9PimXTExXGLAU7p8HzACvXXmO7fMZWxahvWDwrgmlhJ+7S5oYYqkYkCleBtYbHduakGPeWbEwcZjNzLsMFYxQntiM3gz1dUS3DpR5lP+/UhO7HNN81XSgj63K56YO1iS8hX6NzLylOcfxw3wgMtguzIyxLLGfE1rbZkC67D/kfz+jLp6U9ChjqHE3FbSFrl2dhHltdHJ4ErM1vlbTIoa+52ka4WKD2uArgilgTo7wvG1fE9n7SXcK5QdUlb4Voi71UchkkauuNXhq090i6Y6GP1EicHuK6ymT4P9sGwnGoXHPik9v6QuTwxcAZIoR9J6P8CyrL2OHIseh6xQ="
+   :idp-cert certti
    :keystore-file "keystore.jks"
    :keystore-password "changeit"
    :key-alias "mylocalsp"})
@@ -21,4 +23,6 @@
 (defn -main
   "The point of entry for the demo server."
   []
-  (jetty/run-jetty app {:port 8081}))
+  (do
+    (println "Jetty server running on port 8081")
+    (jetty/run-jetty app {:port 8081})))

--- a/src/saml_test/core.clj
+++ b/src/saml_test/core.clj
@@ -18,7 +18,7 @@
    :idp-uri "http://localhost:7000"
    :idp-cert (parse-certificate (slurp "./node_modules/saml-idp/idp-public-cert.pem"))
    :keystore-file "keystore.jks"
-   :keystore-password "changeit"
+   :keystore-password (System/getenv "KEYSTORE_PASS")
    :key-alias "mylocalsp"})
 
 (def app

--- a/src/saml_test/core.clj
+++ b/src/saml_test/core.clj
@@ -1,16 +1,22 @@
 (ns saml-test.core
-  (:require [compojure.core :as core]
+  (:require [clojure.string :as s]
+            [compojure.core :as core]
             [compojure.handler :as handler]
             [ring.adapter.jetty :as jetty]
-            [saml-test.routes :as routes]))
+            [saml-test.routes :as routes]
+            [taoensso.timbre :as timbre :refer [log info trace debug warn error]]))
 
-(def certti (slurp "./node_modules/saml-idp/idp-public-cert.pem"))
+(defn parse-certificate
+  "Strip the ---BEGIN CERTIFICATE--- and ---END CERTIFICATE--- headers and newlines
+  from certificate."
+  [certstring]
+  (->> (s/split certstring #"\n") rest drop-last s/join))
 
 (def config
   {:app-name "Test SAML app"
    :base-uri "http://localhost:8081"
    :idp-uri "http://localhost:7000"
-   :idp-cert certti
+   :idp-cert (parse-certificate (slurp "./node_modules/saml-idp/idp-public-cert.pem"))
    :keystore-file "keystore.jks"
    :keystore-password "changeit"
    :key-alias "mylocalsp"})
@@ -24,5 +30,5 @@
   "The point of entry for the demo server."
   []
   (do
-    (println "Jetty server running on port 8081")
+    (info "Started Jetty server on port 8081...")
     (jetty/run-jetty app {:port 8081})))

--- a/src/saml_test/core.clj
+++ b/src/saml_test/core.clj
@@ -6,7 +6,7 @@
             [saml-test.routes :as routes]
             [taoensso.timbre :as timbre :refer [log info trace debug warn error]]))
 
-(defn parse-certificate
+(defn- parse-certificate
   "Strip the ---BEGIN CERTIFICATE--- and ---END CERTIFICATE--- headers and newlines
   from certificate."
   [certstring]

--- a/src/saml_test/pages.clj
+++ b/src/saml_test/pages.clj
@@ -10,7 +10,7 @@
      [:body.container
       [:h1 "Hey, you've found your local Service Provider!!!"]
       [:p.lead "You can get the SAML metadata for this SP " [:a {:href "/saml/meta"} "here"] "!!!"]
-      [:a.btn.btn-primary {:href "login"} "Take me to the IDP!!!"]]]))
+      [:a.btn.btn-primary {:href "login"} "Take me to the IdP!!!"]]]))
 
 (defn- show-saml-assertions [assertions]
   (for [assertion assertions]
@@ -29,9 +29,9 @@
      [:head
       [:link {:rel "stylesheet" :href "//maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css"}]
       [:style "tr { height: 30px; } td { padding: 10px; }"]
-      [:title "SAML response from IDP"]]
+      [:title "SAML response from IdP"]]
      [:body.container
-      [:h1 "This is the SAML response received from the IDP"]
+      [:h1 "This is the SAML response received from the IdP"]
       [:table {:class "table-bordered table-hover"}
        (for [[k v] saml-info]
          (if (not= k :assertions)
@@ -48,8 +48,8 @@
     [:html
      [:head
       [:link {:rel "stylesheet" :href "//maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css"}]
-      [:title "Congrats, your round-trip to the IDP was successful!"]]
+      [:title "Congrats, your round-trip to the IdP was successful!"]]
      [:body.container
       [:h1 "Everything seems to have worked!"]
-      [:p.lead "You the SAML response from the IDP was valid and your SP->IDP->SP -roundtrip was successful."]
+      [:p.lead "The SAML response from the IdP was valid. Your SP->IdP->SP -roundtrip was successful!"]
       [:a.btn.btn-primary {:href "/"} "Return to main page"]]]))

--- a/src/saml_test/pages.clj
+++ b/src/saml_test/pages.clj
@@ -44,4 +44,12 @@
   "TODO")
 
 (defn target []
-  "TODO")
+  (html5
+    [:html
+     [:head
+      [:link {:rel "stylesheet" :href "//maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css"}]
+      [:title "Congrats, your round-trip to the IDP was successful!"]]
+     [:body.container
+      [:h1 "Everything seems to have worked!"]
+      [:p.lead "You the SAML response from the IDP was valid and your SP->IDP->SP -roundtrip was successful."]
+      [:a.btn.btn-primary {:href "/"} "Return to main page"]]]))

--- a/src/saml_test/routes.clj
+++ b/src/saml_test/routes.clj
@@ -91,9 +91,11 @@
           (if valid?
             (do
               (info "Validation was successful, redirecting client...")
-             {:status  303 ;; See other
-              :headers {"Location" continue-url}
-              :session (assoc session :saml saml-info)
-              :body "Oh yeah, it worked!"})
-           {:status 500
-            :body "The SAML response from IdP does not validate!"}))))))
+              {:status 303
+               :headers {"Location" continue-url}
+               :session (assoc session :saml saml-info)
+               :body "Oh yeah, it worked!"})
+            (do
+              (error "The SAML response from IdP does not validate!")
+              {:status 500
+               :body "The SAML response from IdP does not validate!"})))))))


### PR DESCRIPTION
I came across your project while trying to figure out how to implement SSO with ADFS to our project and found it very informative. However, I couldn't get it to work out of the box. This turned out to be due to the main branch of `saml20-clj` using SHA-1 signing, which neither modern browsers nor ADFS support.

In order to get to grips with SAML, I decided to fork your repo and fix the problem. In order to get SHA-256 to work, I changed the project to use a more recent fork of `saml20-clj` (https://github.com/kirasystems/saml20-clj). I also updated all other dependencies to their latest versions, tweaked the configuration a little bit, added a landing page after getting a valid response from the IdP and updated the docs accordingly.